### PR TITLE
Improve GitHub Actions workflows security and reliability

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,29 +4,27 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version'
+        description: 'Build version image'
         required: true
-        default: 'false'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       version:
-        description: 'Version'
+        description: 'Build version image'
         required: false
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
 
 jobs:
   docker-version:
-    name: Publish Docker Image Version
+    name: Publish Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - name: Cache Docker layers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Check Out Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -40,20 +38,25 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Extract Maven project version
-        run: echo ::set-output name=version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+        if: ${{ inputs.version }}
         id: project
+        run: |
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Show extracted Maven project version
+        if: ${{ inputs.version }}
         run: echo ${{ steps.project.outputs.version }}
 
-      # Get branch name
-      - name: Set env.BRANCH
-        run: echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
-      - name: Get branch name
-        run: echo ${BRANCH}
+      - name: Prepare docker tag from ref
+        id: ref_tag
+        run: |
+          tag="${GITHUB_REF_NAME,,}"
+          tag="${tag//\//-}"
+          echo "value=${tag}" >> "$GITHUB_OUTPUT"
 
       # Create docker image version
       - name: Build and push version
-        if: ${{ inputs.version == 'true' && env.BRANCH != 'develop'}}
+        if: ${{ inputs.version && github.ref_name != 'develop' }}
         id: docker_build_version
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -63,13 +66,16 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:${{ steps.project.outputs.version }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Version image digest
+        if: ${{ inputs.version && github.ref_name != 'develop' }}
+        run: echo ${{ steps.docker_build_version.outputs.digest }}
 
       # Create docker image latest
       - name: Build and push latest
-        if: ${{ inputs.version != 'true' && env.BRANCH == 'develop'}}
-        # if: ${{ env.BRANCH }} == 'develop'
+        if: ${{ inputs.version == false && github.ref_name == 'develop' }}
         id: docker_build_latest
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -79,14 +85,16 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Latest image digest
+        if: ${{ inputs.version == false && github.ref_name == 'develop' }}
+        run: echo ${{ steps.docker_build_latest.outputs.digest }}
 
       # Create docker image branchName
       - name: Build and push branch
-        if: ${{ inputs.version != 'true' && env.BRANCH != 'develop'}}
+        if: ${{ inputs.version == false && github.ref_name != 'develop' }}
         id: docker_build_branch
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -95,8 +103,10 @@ jobs:
           file: ./docker/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+          tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:${{ steps.ref_tag.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Branch image digest
+        if: ${{ inputs.version == false && github.ref_name != 'develop' }}
+        run: echo ${{ steps.docker_build_branch.outputs.digest }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,7 +51,11 @@ jobs:
         id: ref_tag
         run: |
           tag="${GITHUB_REF_NAME,,}"
-          tag="${tag//\//-}"
+          tag="$(printf '%s' "$tag" | sed -E 's/[^a-z0-9_.-]+/-/g; s/^[.-]+//')"
+          tag="${tag:0:128}"
+          if [ -z "$tag" ]; then
+            tag="ref"
+          fi
           echo "value=${tag}" >> "$GITHUB_OUTPUT"
 
       # Create docker image version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,14 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build-app
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -19,19 +23,15 @@ jobs:
           java-version: 25
           distribution: 'temurin'
           cache: 'maven'
-      - name: Cache Maven packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Maven Package
         run: mvn -B clean package
 
   sonar:
     name: Sonar-cloud
+    if: ${{ secrets.SONAR_TOKEN != '' }}
     runs-on: ubuntu-latest
     needs: [ build ]
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -42,12 +42,6 @@ jobs:
           java-version: 25
           distribution: 'temurin'
           cache: 'maven'
-      - name: Cache Maven packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: SonarCloud Scan
         run: mvn -B clean verify -Psonar
         env:

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -4,10 +4,14 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   deploy-artifact:
     name: Deploy-artifact
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       packages: write
@@ -22,6 +26,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Publish artifact on GitHub Packages
-        run: mvn -B -e -X clean deploy -DskipTests
+        run: mvn -B -e clean deploy -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,8 +5,12 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: dev-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   buildAndSonar:
@@ -18,7 +22,6 @@ jobs:
     name: Deploy-artifact
     needs: [ buildAndSonar ]
     permissions:
-      actions: write
       contents: write
       packages: write
     uses: ./.github/workflows/deploy-artifact.yml
@@ -29,5 +32,5 @@ jobs:
     needs: [ buildAndSonar ]
     uses: ./.github/workflows/build-docker.yml
     with:
-      version: 'false'
+      version: false
     secrets: inherit

--- a/.github/workflows/others.yml
+++ b/.github/workflows/others.yml
@@ -6,8 +6,12 @@ on:
       - develop
       - master
 
+concurrency:
+  group: others-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  actions: write
+  contents: read
 jobs:
   buildAndSonar:
     name: Build-app
@@ -19,5 +23,5 @@ jobs:
     needs: [ buildAndSonar ]
     uses: ./.github/workflows/build-docker.yml
     with:
-      version: 'false'
+      version: false
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,8 +4,12 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
-  actions: write
+  contents: read
 jobs:
   buildAndSonar:
     name: Build-app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,12 @@ on:
     tags:
       - 'crypto-tracker-*.*.*'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   buildAndSonar:
@@ -19,5 +23,5 @@ jobs:
     needs: [ buildAndSonar ]
     uses: ./.github/workflows/build-docker.yml
     with:
-      version: 'true'
+      version: true
     secrets: inherit

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -12,6 +12,10 @@ jobs:
   release:
     name: Release-app
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,21 +27,15 @@ jobs:
           java-version: 25
           distribution: 'temurin'
           cache: 'maven'
-      - name: Cache Maven packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: View settings.xml
-        run: cat /home/runner/.m2/settings.xml
       - name: Configure Git user
         run: |
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
       - name: Extract Maven project version
-        run: echo ::set-output name=version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | cut -d "-" -f 1)
         id: project
+        run: |
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | cut -d "-" -f 1)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Show version
         run: |
           echo "Release Version : ${{ steps.project.outputs.version }}"


### PR DESCRIPTION
🔐🚀 Harden and optimize GitHub Actions workflows
## ✨ Summary
- Applied least-privilege permissions across workflows and removed potentially sensitive output.
- Modernized workflow syntax and execution control (GITHUB_OUTPUT, concurrency, timeout-minutes).
- Improved Docker build reliability (boolean inputs, safer ref/tag handling, fixed digest references, gha cache).
- Removed redundant Maven caching to simplify CI and reduce maintenance overhead.
- Made Sonar execution conditional on token availability to avoid avoidable failures in restricted contexts.
---
## 🎯 Why this change
These updates improve CI/CD security, predictability, and resource efficiency while keeping the existing delivery flow intact.
---
## 📦 Scope of changes
.github/workflows/build-docker.yml
- version input migrated to boolean (workflow_dispatch + workflow_call).
- Replaced deprecated ::set-output with GITHUB_OUTPUT.
- Added top-level permissions: contents: read.
- Added timeout-minutes: 30.
- Reworked ref handling using github.ref_name + sanitized branch tag.
- Switched Buildx cache to type=gha.
- Fixed digest output references to correct step IDs.
.github/workflows/build.yml
- Added top-level permissions: contents: read.
- Added timeout-minutes for build and sonar.
- Removed duplicate Maven cache (actions/cache) and kept setup-java Maven cache.
- Sonar job now runs only when SONAR_TOKEN is present.
.github/workflows/deploy-artifact.yml
- Added top-level minimal permissions.
- Added timeout-minutes: 20.
- Reduced Maven deploy verbosity (removed -X).
.github/workflows/dev.yml
- Added concurrency per branch with cancellation enabled.
- Reduced global permissions to contents: read.
- Removed unnecessary actions: write from deploy job.
- Updated reusable Docker input to boolean (version: false).
.github/workflows/others.yml
- Added concurrency per branch.
- Reduced global permissions.
- Updated reusable Docker input to boolean (version: false).
.github/workflows/pull-request.yml
- Added PR-based concurrency group.
- Reduced global permissions to read-only contents.
.github/workflows/release.yml
- Added tag-based concurrency.
- Reduced global permissions.
- Updated reusable Docker input to boolean (version: true).
.github/workflows/start-release.yml
- Added explicit permissions (contents: write, packages: write).
- Added timeout-minutes: 30.
- Removed settings.xml print step.
- Removed duplicate Maven cache.
- Replaced deprecated output syntax with GITHUB_OUTPUT.
---
## 📊 Impact table
| Area | Before | After |
| --- | --- | --- |
| Workflow outputs | `set-output` (deprecated) | `GITHUB_OUTPUT` |
| Permissions | Broad / inconsistent | Least-privilege baseline |
| Duplicate runs | Could stack per branch/PR | `concurrency` cancellation |
| Job hangs | No explicit time limits in key jobs | `timeout-minutes` added |
| Maven caching | Dual cache strategy | Single cache strategy (`setup-java`) |
| Docker cache | Local tmp cache | `type=gha` cache |
| Sonar behavior | Could fail without token contexts | Conditional execution |
| Sensitive logs | `settings.xml` displayed | Removed |
---
## ✅ Validation checklist
- [ ] Push to `develop` and confirm build/deploy/docker flow passes.
- [ ] Push to a feature branch and confirm branch Docker tag build works.
- [ ] Open/update PR and confirm previous run gets canceled (`concurrency`).
- [ ] Verify Sonar runs when `SONAR_TOKEN` exists; skipped otherwise.
- [ ] Create tag `crypto-tracker-x.y.z` and confirm release + versioned Docker image.
- [ ] Manually run `start-release` and verify no sensitive config is printed.
---
## ⚠️ Risks / compatibility notes
- Reusable workflow callers must pass version as boolean (true/false), not string ('true'/'false').
- Sonar being skipped without token is intentional and expected.
- concurrency now cancels outdated in-progress runs for the same branch/PR.
---
## 🔄 Rollback plan
1. Revert this PR entirely if needed.
2. Partial rollback options:
   - Remove concurrency blocks.
   - Revert boolean input migration in Docker workflow and callers.
   - Restore previous cache approach if regressions are observed.
3. Re-run develop, PR, and tagged release pipelines to verify stability.