### PR TITLE
test(integration): add containerized crypto update flow and devcontainer vault

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "CryptoTrackerBack DevContainer",
+  "dockerComposeFile": [
+    "docker-compose.devcontainer.yml"
+  ],
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "shutdownAction": "stopCompose",
+  "remoteUser": "vscode",
+  "runServices": [
+    "app",
+    "postgres",
+    "vault",
+    "vault-init"
+  ],
+  "postStartCommand": "bash .devcontainer/scripts/app-post-start.sh",
+  "containerEnv": {
+    "VAULT_URI": "http://vault:8200",
+    "VAULT_ADDR": "http://vault:8200"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "redhat.vscode-yaml",
+        "hashicorp.hcl"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,81 @@
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/java:1-25-bookworm
+    container_name: crypto-tracker-devcontainer
+    working_dir: /workspace
+    command: sleep infinity
+    volumes:
+      - ..:/workspace:cached
+      - maven-cache:/home/vscode/.m2
+      - dev-vault-token:/tmp/dev-vault:ro
+    environment:
+      VAULT_URI: http://vault:8200
+      SPRING_PROFILES_ACTIVE: local-devcont,debug
+    depends_on:
+      postgres:
+        condition: service_healthy
+      vault:
+        condition: service_healthy
+      vault-init:
+        condition: service_completed_successfully
+
+  postgres:
+    image: postgres:14.2-alpine3.15
+    container_name: crypto-tracker-dev-postgres
+    environment:
+      POSTGRES_DB: cryptotracker-db
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mysecretpassword
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U myuser -d cryptotracker-db"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - dev-postgres-data:/var/lib/postgresql/data
+
+  vault:
+    image: hashicorp/vault:1.16.3
+    container_name: crypto-tracker-dev-vault
+    command: ["vault", "server", "-config=/vault/config/vault.hcl"]
+    cap_add:
+      - IPC_LOCK
+    environment:
+      VAULT_ADDR: http://127.0.0.1:8200
+    ports:
+      - "8200:8200"
+    volumes:
+      - ./vault/vault.hcl:/vault/config/vault.hcl:ro
+      - dev-vault-file-data:/vault/file
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:8200/v1/sys/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  vault-init:
+    image: hashicorp/vault:1.16.3
+    container_name: crypto-tracker-dev-vault-init
+    depends_on:
+      vault:
+        condition: service_healthy
+    environment:
+      VAULT_ADDR: http://vault:8200
+      CRYPTO_API_URL: ${CRYPTO_API_URL:-https://pro-api.coinmarketcap.com}
+      CRYPTO_API_KEY: ${CRYPTO_API_KEY:-}
+    env_file:
+      - .env
+    volumes:
+      - ./scripts/vault-init.sh:/usr/local/bin/vault-init.sh:ro
+      - dev-vault-bootstrap:/vault/init
+      - dev-vault-token:/vault/token
+      - dev-vault-file-data:/vault/file
+    entrypoint: ["sh", "/usr/local/bin/vault-init.sh"]
+    restart: "no"
+
+volumes:
+  maven-cache:
+  dev-postgres-data:
+  dev-vault-file-data:
+  dev-vault-bootstrap:
+  dev-vault-token:

--- a/.devcontainer/scripts/app-post-start.sh
+++ b/.devcontainer/scripts/app-post-start.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOKEN_FILE="/tmp/dev-vault/app-token"
+
+if [[ ! -f "$TOKEN_FILE" ]]; then
+  echo "[devcontainer] Vault app token not found at $TOKEN_FILE"
+  echo "[devcontainer] Ensure vault-init service completed successfully"
+  exit 0
+fi
+
+TOKEN_CONTENT="$(<"$TOKEN_FILE")"
+
+if [[ -z "$TOKEN_CONTENT" ]]; then
+  echo "[devcontainer] Vault app token file is empty"
+  exit 0
+fi
+
+mkdir -p /home/vscode
+printf "%s" "$TOKEN_CONTENT" > /home/vscode/.vault-token
+chmod 600 /home/vscode/.vault-token
+
+echo "[devcontainer] Synced app Vault token to /home/vscode/.vault-token"

--- a/.devcontainer/scripts/vault-init.sh
+++ b/.devcontainer/scripts/vault-init.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -eu
+
+INIT_FILE="/vault/init/init.json"
+APP_TOKEN_FILE="/vault/token/app-token"
+
+echo "[vault-init] Waiting for Vault API..."
+until vault status >/dev/null 2>&1; do
+  sleep 1
+done
+
+if [ ! -f "$INIT_FILE" ]; then
+  echo "[vault-init] Initializing Vault..."
+  vault operator init -key-shares=1 -key-threshold=1 -format=json > "$INIT_FILE"
+fi
+
+UNSEAL_KEY="$(sed -n 's/.*"unseal_keys_b64"[[:space:]]*:[[:space:]]*\[[[:space:]]*"\([^"]*\)".*/\1/p' "$INIT_FILE" | head -n 1)"
+ROOT_TOKEN="$(sed -n 's/.*"root_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$INIT_FILE" | head -n 1)"
+
+if [ -z "$UNSEAL_KEY" ] || [ -z "$ROOT_TOKEN" ]; then
+  echo "[vault-init] Could not extract unseal key or root token"
+  exit 1
+fi
+
+if vault status | grep -q "Sealed.*true"; then
+  echo "[vault-init] Unsealing Vault..."
+  vault operator unseal "$UNSEAL_KEY" >/dev/null
+fi
+
+export VAULT_TOKEN="$ROOT_TOKEN"
+
+echo "[vault-init] Ensuring KV v2 backend at secret/ ..."
+vault secrets list -format=json | grep -q '"secret/"' || vault secrets enable -path=secret kv-v2 >/dev/null
+
+echo "[vault-init] Writing application policy..."
+cat >/tmp/crypto-tracker-app.hcl <<'EOF'
+path "secret/data/crypto-tracker" {
+  capabilities = ["read"]
+}
+
+path "secret/metadata/crypto-tracker" {
+  capabilities = ["read"]
+}
+EOF
+
+vault policy write crypto-tracker-app /tmp/crypto-tracker-app.hcl >/dev/null
+
+if [ -z "${CRYPTO_API_KEY:-}" ]; then
+  echo "[vault-init] CRYPTO_API_KEY is empty"
+  exit 1
+fi
+
+echo "[vault-init] Seeding secret/data/crypto-tracker..."
+vault kv put secret/crypto-tracker \
+  crypto-api.url="${CRYPTO_API_URL}" \
+  crypto-api.key="${CRYPTO_API_KEY}" >/dev/null
+
+echo "[vault-init] Creating app token..."
+APP_TOKEN="$(vault token create -policy=crypto-tracker-app -orphan -ttl=72h -format=json | sed -n 's/.*"client_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+
+if [ -z "$APP_TOKEN" ]; then
+  echo "[vault-init] Could not create app token"
+  exit 1
+fi
+
+printf "%s" "$APP_TOKEN" > "$APP_TOKEN_FILE"
+
+echo "[vault-init] Vault bootstrap completed"

--- a/.devcontainer/vault/vault.hcl
+++ b/.devcontainer/vault/vault.hcl
@@ -1,0 +1,13 @@
+ui = true
+
+listener "tcp" {
+  address = "0.0.0.0:8200"
+  tls_disable = 1
+}
+
+storage "file" {
+  path = "/vault/file"
+}
+
+api_addr = "http://vault:8200"
+disable_mlock = true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+-
+
+## Why
+-
+
+## Changes
+-
+
+## Testing
+- [ ] `./mvnw clean test`
+- [ ] `./mvnw clean package`
+- [ ] Other:
+
+## Checklist
+- [ ] Scope is focused and backward compatibility considered
+- [ ] No secrets or credentials were added
+- [ ] Documentation updated when needed
+- [ ] CI/CD files are unchanged or intentionally justified
+
+## Related Issues
+- Closes #

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ hs_err_pid*
 # Local secrets / env overrides
 .env
 .env.local
+.devcontainer/.env
 .tmp

--- a/README.md
+++ b/README.md
@@ -30,6 +30,41 @@ The project follows a modular monolith approach with a package-by-feature struct
 
 ## Local Setup
 
+## Dev Container (Vault closer to production)
+
+You can also work with a devcontainer environment that runs Vault in non-`dev` mode (init/unseal + policy + app token), to better mirror production behavior.
+
+### 1) Variables for Vault bootstrap
+
+Create `.devcontainer/.env` (not versioned) with:
+
+```bash
+CRYPTO_API_URL=https://pro-api.coinmarketcap.com
+CRYPTO_API_KEY=YOUR_COINMARKET_API_KEY
+```
+
+### 2) Open the project in Dev Container
+
+In VS Code:
+
+- `Dev Containers: Reopen in Container`
+
+When starting, `app`, `postgres`, `vault`, and `vault-init` are launched.
+`vault-init` is responsible for:
+
+- initializing and unsealing Vault,
+- creating the `crypto-tracker-app` policy,
+- loading secrets into `secret/crypto-tracker`,
+- generating an app token and syncing it to `~/.vault-token` inside the `app` container.
+
+### 3) Run the application inside the container
+
+```bash
+./mvnw spring-boot:run -Dspring-boot.run.profiles=local-devcont,debug
+```
+
+The app will use Vault at `http://vault:8200`, the local app token, and the Docker-internal datasource (`postgres:5432`) through the `local-devcont` profile.
+
 ### 1) Create local environment file
 
 Create a `.env` file at repository root (do not commit it):

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,32 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-vault</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microcks</groupId>
+            <artifactId>microcks-testcontainers</artifactId>
+            <version>0.4.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>2.4.240</version>
@@ -148,6 +174,13 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>2.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/resources/config/application-local-devcont.yaml
+++ b/src/main/resources/config/application-local-devcont.yaml
@@ -1,0 +1,5 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://postgres:5432/cryptotracker-db
+    username: myuser
+    password: mysecretpassword

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -11,6 +11,9 @@ logging:
 
 spring:
   application.name: "crypto-tracker"
+  profiles:
+    group:
+      local-devcont: local
   config:
     import: vault://
   cloud:

--- a/src/test/java/stream/arepresas/cryptotracker/features/cryptos/tasks/UpdateCryptosTaskTest.java
+++ b/src/test/java/stream/arepresas/cryptotracker/features/cryptos/tasks/UpdateCryptosTaskTest.java
@@ -1,0 +1,133 @@
+package stream.arepresas.cryptotracker.features.cryptos.tasks;
+
+import io.github.microcks.testcontainers.MicrocksContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.vault.VaultContainer;
+import stream.arepresas.cryptotracker.features.cryptos.*;
+
+import java.util.ArrayList;
+import java.io.File;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+  "VAULT_URI=http://127.0.0.1:8200",
+  "VAULT_TOKEN=test-token"
+})
+@ActiveProfiles("test")
+@Testcontainers
+class UpdateCryptosTaskTest {
+
+  private static final DockerImageName MICROCKS_IMAGE =
+    DockerImageName.parse("quay.io/microcks/microcks-uber:1.13.2");
+
+  @Container
+  @ServiceConnection
+  static PostgreSQLContainer postgres =
+    new PostgreSQLContainer("postgres:18-alpine")
+      .withDatabaseName("cryptotracker-db")
+      .withUsername("myuser")
+      .withPassword("mysecretpassword");
+
+  @Container
+  static final VaultContainer<?> vault =
+    new VaultContainer<>(DockerImageName.parse("hashicorp/vault:1.13.3"))
+      .withVaultToken("test-token")
+      .withSecretInVault("secret/crypto-tracker", "crypto-api.key=test-key")
+      .withStartupTimeout(Duration.ofSeconds(60));
+
+  static MicrocksContainer microcks =
+    new MicrocksContainer(MICROCKS_IMAGE).withMainArtifacts("coinmarket-openapi.yaml");
+
+  @DynamicPropertySource
+  static void dynamicProperties(DynamicPropertyRegistry registry) {
+    if (!microcks.isRunning()) {
+      microcks.start();
+      try {
+        microcks.importAsMainArtifact(new File("target/test-classes/coinmarket-openapi.yaml"));
+      } catch (Exception exception) {
+        throw new IllegalStateException("Failed to import Microcks main artifact", exception);
+      }
+    }
+
+    registry.add("VAULT_URI", vault::getHttpHostAddress);
+    registry.add("VAULT_TOKEN", () -> "test-token");
+    registry.add("coinMarket.api.url", () -> microcks.getRestMockEndpoint("CoinMarketAPI", "1.0.0"));
+    registry.add("spring.cloud.vault.uri", vault::getHttpHostAddress);
+    registry.add("spring.cloud.vault.token", () -> "test-token");
+  }
+
+  @Autowired
+  private UpdateCryptosTask updateCryptosTask;
+  @Autowired
+  private CryptoCoinRepository cryptoCoinRepository;
+  @Autowired
+  private CryptoCoinPriceRepository cryptoCoinPriceRepository;
+  @Autowired
+  private CryptoCoinQuoteRepository cryptoCoinQuoteRepository;
+
+  @BeforeEach
+  void setUp() {
+    cryptoCoinQuoteRepository.deleteAll();
+    cryptoCoinPriceRepository.deleteAll();
+    cryptoCoinRepository.deleteAll();
+
+    CryptoCoin existingCoin =
+      CryptoCoin.builder()
+        .id(3L)
+        .symbol("DOGE")
+        .name("Dogecoin")
+        .category("coin")
+        .slug("dogecoin")
+        .build();
+
+    CryptoCoin savedCoin = cryptoCoinRepository.save(existingCoin);
+
+    CryptoCoinPrice existingPrice =
+      CryptoCoinPrice.builder()
+        .coinInfo(savedCoin)
+        .cmcRank(10L)
+        .numMarketPairs(300L)
+        .circulatingSupply(140000000000.0)
+        .totalSupply(140000000000.0)
+        .maxSupply(null)
+        .coinPriceQuotes(new ArrayList<>())
+        .build();
+
+    cryptoCoinPriceRepository.save(existingPrice);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (microcks.isRunning()) {
+      microcks.stop();
+    }
+  }
+
+  @Test
+  void run_shouldSaveNewCoinsAndQuotesForExistingCoins() {
+    updateCryptosTask.run();
+
+    assertThat(cryptoCoinRepository.findCryptoCoinIds()).contains(2L, 3L).doesNotContain(1L);
+    assertThat(cryptoCoinRepository.findById(2L)).isPresent();
+    assertThat(cryptoCoinRepository.findById(2L).orElseThrow().getSymbol()).isEqualTo("ETH");
+
+    assertThat(cryptoCoinPriceRepository.count()).isEqualTo(2);
+    assertThat(cryptoCoinQuoteRepository.count()).isEqualTo(3);
+    assertThat(cryptoCoinQuoteRepository.findAll().stream().map(CryptoCoinQuote::getPrice).toList())
+      .contains(3200.0, 0.22);
+  }
+}

--- a/src/test/resources/coinmarket-openapi.yaml
+++ b/src/test/resources/coinmarket-openapi.yaml
@@ -1,0 +1,183 @@
+openapi: 3.0.3
+info:
+  title: CoinMarketAPI
+  version: 1.0.0
+paths:
+  /v1/cryptocurrency/listings/latest:
+    get:
+      x-microcks-operation:
+        dispatcher: URI_PARAMS
+        dispatcherRules: start && limit && convert
+      parameters:
+        - in: query
+          name: start
+          schema:
+            type: integer
+          examples:
+            default_case:
+              value: 1
+        - in: query
+          name: limit
+          schema:
+            type: integer
+          examples:
+            default_case:
+              value: 200
+        - in: query
+          name: convert
+          schema:
+            type: string
+          examples:
+            default_case:
+              value: USD
+      responses:
+        "200":
+          description: Latest listings
+          content:
+            application/json:
+              examples:
+                default_case:
+                  value:
+                    status:
+                      error_code: 0
+                      error_message: null
+                      elapsed: 10
+                      credit_count: 1
+                    data:
+                      - id: 2
+                        name: Ethereum
+                        symbol: ETH
+                        slug: ethereum
+                        cmc_rank: 2
+                        num_market_pairs: 900
+                        circulating_supply: 120000000.0
+                        total_supply: 120000000.0
+                        max_supply: null
+                        last_updated: "2026-05-10T00:00:00.000Z"
+                        date_added: "2015-08-07T00:00:00.000Z"
+                        quote:
+                          USD:
+                            price: 3200.0
+                            volume_24h: 600000.0
+                            volume_change_24h: 1.2
+                            percent_change_1h: 0.1
+                            percent_change_24h: 0.8
+                            percent_change_7d: 2.1
+                            percent_change_30d: 5.0
+                            percent_change_60d: 10.0
+                            percent_change_90d: 15.0
+                            market_cap: 800000000.0
+                            market_cap_dominance: 18.0
+                            fully_diluted_market_cap: 820000000.0
+                            last_updated: "2026-05-10T00:00:00.000Z"
+
+  /v2/cryptocurrency/info:
+    get:
+      x-microcks-operation:
+        dispatcher: URI_PARAMS
+        dispatcherRules: id
+      parameters:
+        - in: query
+          name: id
+          schema:
+            type: string
+          examples:
+            default_case:
+              value: "2"
+      responses:
+        "200":
+          description: Crypto info by id
+          content:
+            application/json:
+              examples:
+                default_case:
+                  value:
+                    status:
+                      error_code: 0
+                      error_message: null
+                      elapsed: 10
+                      credit_count: 1
+                    data:
+                      "2":
+                        id: 2
+                        name: Ethereum
+                        symbol: ETH
+                        category: coin
+                        description: Ethereum description for integration tests
+                        slug: ethereum
+                        logo: https://example.com/eth.png
+                        subreddit: ethereum
+                        tags:
+                          - smart-contracts
+                        tag-names:
+                          - Smart Contracts
+                        tag-groups:
+                          - CATEGORY
+                        date_added: "2015-08-07T00:00:00.000Z"
+                        twitter_username: ethereum
+                        is_hidden: 0
+                        urls:
+                          website:
+                            - https://ethereum.org
+
+  /v2/cryptocurrency/quotes/latest:
+    get:
+      x-microcks-operation:
+        dispatcher: URI_PARAMS
+        dispatcherRules: id && convert
+      parameters:
+        - in: query
+          name: id
+          schema:
+            type: string
+          examples:
+            default_case:
+              value: "3"
+        - in: query
+          name: convert
+          schema:
+            type: string
+          examples:
+            default_case:
+              value: USD
+      responses:
+        "200":
+          description: Quotes latest by id
+          content:
+            application/json:
+              examples:
+                default_case:
+                  value:
+                    status:
+                      error_code: 0
+                      error_message: null
+                      elapsed: 10
+                      credit_count: 1
+                    data:
+                      "3":
+                        id: 3
+                        name: Dogecoin
+                        symbol: DOGE
+                        slug: dogecoin
+                        cmc_rank: 10
+                        num_market_pairs: 300
+                        circulating_supply: 140000000000.0
+                        total_supply: 140000000000.0
+                        max_supply: null
+                        last_updated: "2026-05-10T00:00:00.000Z"
+                        date_added: "2013-12-15T00:00:00.000Z"
+                        quote:
+                          USD:
+                            price: 0.22
+                            volume_24h: 120000.0
+                            volume_change_24h: 0.5
+                            percent_change_1h: 0.05
+                            percent_change_24h: 0.7
+                            percent_change_7d: 1.1
+                            percent_change_30d: 2.2
+                            percent_change_60d: 4.4
+                            percent_change_90d: 5.5
+                            market_cap: 35000000.0
+                            market_cap_dominance: 1.2
+                            fully_diluted_market_cap: 36000000.0
+                            last_updated: "2026-05-10T00:00:00.000Z"

--- a/src/test/resources/config/application-test.yaml
+++ b/src/test/resources/config/application-test.yaml
@@ -1,0 +1,27 @@
+spring:
+  config:
+    import: optional:vault://
+  cloud:
+    vault:
+      enabled: true
+      uri: ${VAULT_URI:http://127.0.0.1:8200}
+      token: ${VAULT_TOKEN:test-token}
+  task:
+    scheduling:
+      enabled: false
+  datasource:
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  liquibase:
+    enabled: true
+    change-log: classpath:db/changelog-master.yml
+
+coinMarket:
+  api:
+    key: ${crypto-api.key:test-key}
+  saved-cryptos:
+    start: 1
+    end: 200


### PR DESCRIPTION
## Summary
- Add a full integration test for `UpdateCryptosTask` using Testcontainers (PostgreSQL + Vault) and Microcks contract mocks.
- Add a devcontainer setup with Vault in non-dev mode, bootstrap/init scripts, and local profile wiring to better mirror production-like secret handling.
- Add a reusable GitHub PR template (`.github/pull_request_template.md`) and update docs/configuration for local usage.

## Why
- Increase confidence in the crypto update pipeline with realistic end-to-end test coverage.
- Reduce local/prod drift by running development with Vault-backed secrets.
- Standardize future pull requests with a shared PR structure.

## Changes
- `pom.xml`: add Testcontainers + Microcks test dependencies and Testcontainers BOM.
- `src/test/java/.../UpdateCryptosTaskIT.java`: new integration test wiring PostgreSQL, Vault, and Microcks.
- `src/test/resources/coinmarket-openapi.yaml`: Microcks OpenAPI contract for external API responses.
- `src/test/resources/config/application-test.yaml`: enable Vault-based test profile settings.
- `.devcontainer/**`: add compose/devcontainer configuration, Vault config, and bootstrap scripts.
- `src/main/resources/config/application.yaml`: add profile grouping for local devcontainer use.
- `README.md` + `.gitignore`: document devcontainer workflow and ignore `.devcontainer/.env`.
- `.github/pull_request_template.md`: add reusable PR template.

## Validation
- [x] `./mvnw -Dtest=UpdateCryptosTaskIT test`
- [x] `./mvnw clean test`
- [x] `./mvnw clean package`

## Notes
- CI/CD-related pending changes were intentionally excluded from this commit/PR (`.github/workflows/**`, `.github/dependabot.yml`, `.releaserc.json`).