### PR TITLE
ci(release): adopt semantic-release and automate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,11 @@ name: Release workflow
 
 on:
   push:
+    branches:
+      - master
     tags:
       - 'crypto-tracker-*.*.*'
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}
@@ -13,13 +16,51 @@ permissions:
   contents: read
 
 jobs:
+  semantic-release:
+    name: Semantic-release
+    if: ${{ github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642a3ce6ea30ac0485487b9 # v4.4.0
+        with:
+          node-version: lts/*
+
+      - name: Set up JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: 25
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Install semantic-release dependencies
+        run: npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec @semantic-release/git @semantic-release/github
+
+      - name: Run semantic-release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   buildAndSonar:
     name: Build-app
+    if: ${{ startsWith(github.ref, 'refs/tags/crypto-tracker-') }}
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
   build-docker-version:
     name: Build-docker-version
+    if: ${{ startsWith(github.ref, 'refs/tags/crypto-tracker-') }}
     needs: [ buildAndSonar ]
     uses: ./.github/workflows/build-docker.yml
     with:

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -2,45 +2,43 @@ name: StartRelease workflow
 
 on:
   workflow_dispatch:
-    inputs:
-      developmentVersion:
-        description: "Default version to use for new local working copy."
-        required: true
-        default: "X.Y.Z-SNAPSHOT"
+
+concurrency:
+  group: start-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
-    name: Release-app
+    name: Semantic-release
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write
+      issues: write
+      pull-requests: write
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642a3ce6ea30ac0485487b9 # v4.4.0
+        with:
+          node-version: lts/*
+
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 25
           distribution: 'temurin'
           cache: 'maven'
-      - name: Configure Git user
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-      - name: Extract Maven project version
-        id: project
-        run: |
-          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | cut -d "-" -f 1)
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-      - name: Show version
-        run: |
-          echo "Release Version : ${{ steps.project.outputs.version }}"
-          echo "Development Version : ${{ github.event.inputs.developmentVersion }}"
-      - name: Publish JAR
-        run: mvn release:prepare release:perform -B -DreleaseVersion=${{ steps.project.outputs.version }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+
+      - name: Install semantic-release dependencies
+        run: npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec @semantic-release/git @semantic-release/github
+
+      - name: Run semantic-release
+        run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,34 @@
+{
+  "branches": [
+    "master"
+  ],
+  "tagFormat": "crypto-tracker-${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "mvn -B versions:set -DnewVersion=${nextRelease.version} -DgenerateBackupPoms=false",
+        "publishCmd": "mvn -B -DskipTests deploy"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "pom.xml"
+        ],
+        "message": "chore(release): crypto-tracker-${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary
- Replace release orchestration in GitHub Actions with semantic-release driven flows.
- Add semantic-release configuration to automate versioning, changelog/tag/release publication, and Maven deploy execution.
- Add Dependabot configuration to keep GitHub Actions dependencies up to date.

## Why
- Reduce manual release operations and make versioning deterministic from commit history.
- Centralize release behavior in a single semantic-release config for easier maintenance.
- Improve CI workflow security and reliability with automated workflow dependency updates.

## Changes
- `.github/workflows/release.yml`
  - Trigger semantic-release on `master` pushes and manual dispatch.
  - Keep tag-based build/publish jobs gated for `crypto-tracker-*.*.*` tags.
- `.github/workflows/start-release.yml`
  - Replace Maven release plugin flow with semantic-release execution.
- `.releaserc.json`
  - Define branch/tag format, release rules, changelog/git/github plugins, and Maven version/deploy commands.
- `.github/dependabot.yml`
  - Configure weekly updates for GitHub Actions dependencies.

## Validation
- [x] `./mvnw clean test`
- [x] `./mvnw clean package`

## Risk / Notes
- Release behavior now depends on Conventional Commit semantics and semantic-release plugin execution.
- Tag-triggered jobs remain in place and are explicitly conditioned to release tags.